### PR TITLE
Update npm to Compatible Version 10.8.2 for Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18
 WORKDIR /opt
 ADD . /opt
-RUN npm install -g npm@latest
+RUN npm install -g npm@10.8.2
 ENTRYPOINT ["npm" "run" "start"]


### PR DESCRIPTION
- Set npm to version 10.8.2, which is fully compatible with Node 18.